### PR TITLE
feat: CI/CD

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -1,0 +1,33 @@
+name: Autobuild
+on: 
+    push:
+        branches: [main]
+    
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Install mdbook
+            run: |
+              sudo apt -q update
+              sudo apt -q install -y jq curl
+              MDBOOK_VERSION=$(curl -s https://api.github.com/repos/rust-lang/mdBook/releases/latest | jq -r .tag_name)
+              curl -sLO "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+              tar -zxvf "mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+              sudo mv mdbook /usr/local/bin/mdbook
+          - name: Checkout
+            uses: actions/checkout@v2
+          - name: Build Book
+            run: mdbook build
+          - name: Push To Branch
+            run: |
+              git worktree add gh-pages
+              git config user.name "github-actions"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              cd gh-pages
+              git update-ref -d refs/heads/gh-pages
+              rm -rf *
+              mv ../book/* .
+              git add .
+              git commit -m "Deploy $GITHUB_SHA to gh-pages"
+              git push --force --set-upstream origin gh-pages


### PR DESCRIPTION
use github actions to deploy built book to gh-pages branch.